### PR TITLE
Automate web build and local UI path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.16)
+project(StremioRevamped)
+
+include(ExternalProject)
+
+# Ensure webapp folder exists
+file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/webapp)
+
+ExternalProject_Add(stremio_web
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/stremio-web
+    BINARY_DIR ${CMAKE_BINARY_DIR}/stremio-web-build
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND npm ci && npm run build
+    BUILD_WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/stremio-web
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/webapp
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${CMAKE_SOURCE_DIR}/stremio-web/dist
+                ${CMAKE_SOURCE_DIR}/webapp
+)
+
+add_subdirectory(stremio-webViewer)
+
+add_dependencies(stremio stremio_web)
+
+install(TARGETS stremio RUNTIME DESTINATION bin)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/webapp DESTINATION bin/webapp)
+
+include(InstallRequiredSystemLibraries)
+set(CPACK_PACKAGE_NAME "StremioRevamped")
+set(CPACK_PACKAGE_VERSION_MAJOR "1")
+set(CPACK_PACKAGE_VERSION_MINOR "0")
+set(CPACK_GENERATOR "ZIP;NSIS;TGZ;DEB;RPM")
+include(CPack)

--- a/stremio-web
+++ b/stremio-web
@@ -1,0 +1,1 @@
+stremio-webBackend

--- a/stremio-webViewer/src/webview/webview.cpp
+++ b/stremio-webViewer/src/webview/webview.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <fstream>
 #include <iostream>
+#include <filesystem>
 #include <Shlwapi.h>
 #include <wrl.h>
 #include "../core/globals.h"
@@ -293,10 +294,12 @@ void InitWebView2(HWND hWnd)
                     SetupWebMessageHandler();
 
                     std::thread([](){
-                        std::wcout << L"[WEBVIEW]: Checking web ui endpoints..." << std::endl;
-                        std::wstring foundUrl = GetFirstReachableUrl();
-                        std::wstring* pResult = new std::wstring(foundUrl);
-                        g_webuiUrl = foundUrl;
+                        wchar_t exePath[MAX_PATH];
+                        GetModuleFileNameW(nullptr, exePath, MAX_PATH);
+                        std::filesystem::path exeDir = std::filesystem::path(exePath).parent_path();
+                        std::filesystem::path indexPath = exeDir / L"webapp" / L"index.html";
+                        g_webuiUrl = indexPath.wstring();
+                        std::wstring* pResult = new std::wstring(g_webuiUrl);
                         PostMessage(g_hWnd, WM_REACHABILITY_DONE, (WPARAM)pResult, 0);
                         FetchAndParseWhitelist();
                     }).detach();


### PR DESCRIPTION
## Summary
- load local webapp path in the C++ webview wrapper
- automate building of the web project via ExternalProject
- include the generated webapp in install rules and enable CPack packaging

## Testing
- `cmake -B build -G "Ninja"` *(fails: Could not find nlohmann_json)*

------
https://chatgpt.com/codex/tasks/task_e_6860a4dabfb0832689f5c952ef58bc26